### PR TITLE
[SOLVE] #88백준 6594 풀이

### DIFF
--- a/src/main/java/baekjoon/barkingdog/stack/Platinum6549.kt
+++ b/src/main/java/baekjoon/barkingdog/stack/Platinum6549.kt
@@ -1,0 +1,38 @@
+package baekjoon.barkingdog.stack
+
+import java.util.*
+import kotlin.collections.ArrayDeque
+
+// n (1<= n <= 10만)
+// 높이 (0 <= 높이 <= 10억)
+// 직사각형의 넓이 Int 벗어날 수 있음
+fun main(){
+        while (true) {
+            val input = readln()
+            if(input == "0") break
+
+            val st = StringTokenizer(input)
+            val n = st.nextToken().toInt()
+            val heights = IntArray(n+1){
+                if(it == n) 0 else st.nextToken().toInt()
+            }
+
+            val stack = ArrayDeque<Int>()
+            var maxArea = 0L
+
+            var i = 0
+            while (i <= n) {
+                // 현재 높이보다 높은 막대가 스택에 남아있으면 팝하며 면적 계산
+                while (stack.isNotEmpty() && heights[stack.last()] > heights[i]) {
+                    val height = heights[stack.removeLast()].toLong()
+                    val width = if (stack.isEmpty()) i else i - stack.last() - 1
+                    val area = height * width
+                    if (area > maxArea) maxArea = area
+                }
+                stack.addLast(i)
+                i++
+            }
+
+            println(maxArea)
+        }
+}


### PR DESCRIPTION
close #88 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 히스토그램에서 가장 큰 직사각형 넓이를 계산하는 기능을 추가했습니다. 여러 테스트 케이스를 연속으로 처리하며, 각 케이스의 최대 넓이를 출력합니다. 입력은 각 줄에 막대 개수와 높이들이 주어지며, ‘0’만 있는 줄에서 종료됩니다. 대용량 입력에서도 빠르게 동작하고, 매우 큰 값에 대해서도 안전하게 계산합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->