### PR TITLE
[SOLVE] #114 백준 10799 풀이

### DIFF
--- a/src/main/java/baekjoon/barkingdog/stack2/Silver10799.kt
+++ b/src/main/java/baekjoon/barkingdog/stack2/Silver10799.kt
@@ -1,0 +1,24 @@
+package baekjoon.barkingdog.stack2
+
+fun main(){
+    val parentheses = readln()
+    val stack = ArrayDeque<Char>()
+    var answer = 0
+    parentheses.forEachIndexed{ index, parenthesis ->
+        when(parenthesis){
+            '(' -> {
+                stack.addLast('(')
+            }
+            ')' -> {
+                if(parentheses[index-1] == '(') {
+                    stack.removeLast()
+                    answer += stack.size
+                }else{
+                    stack.removeLast()
+                    answer += 1
+                }
+            }
+        }
+    }
+    println(answer)
+}


### PR DESCRIPTION
close #114 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 백준 10799(쇠막대기) 문제 풀이를 추가했습니다. 한 줄 괄호 입력을 스택 방식으로 처리해 레이저와 막대 끝을 구분하고, 잘려 나오는 막대 조각 수를 계산해 출력합니다. 커맨드라인에서 바로 실행 가능한 진입점이 포함되어 있어 즉시 실행 및 확인이 가능합니다. 표준 입력을 통해 문자열을 전달하면 결과를 출력하며, 연습과 검증 용도로 활용하기 적합합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->