### PR TITLE
[SOLVE] #128 백준 7569 풀이

### DIFF
--- a/src/main/java/baekjoon/barkingdog/bfs/Gold7569.kt
+++ b/src/main/java/baekjoon/barkingdog/bfs/Gold7569.kt
@@ -1,0 +1,49 @@
+package baekjoon.barkingdog.bfs
+
+fun main() {
+    val rowDirection = intArrayOf(-1, 0, 0, 0, 0, 1)
+    val columnDirection = intArrayOf(0, -1, 1, 0, 0, 0)
+    val zDirection = intArrayOf(0, 0, 0, -1, 1, 0)
+    val queue = ArrayDeque<Triple<Int, Int, Int>>()
+
+    val (columns, rows, height) = readln().split(" ").map{ it.toInt() }
+    val farm = Array(height){
+        Array(rows){
+            readln().split(" ").map{ it.toInt() }.toIntArray()
+        }
+    }
+    farm.forEachIndexed{ zIndex,  grid->
+        grid.forEachIndexed{ rowIndex, row ->
+            row.forEachIndexed{ columnIndex, tomato ->
+                if(tomato == 1) queue.addLast(Triple(zIndex, rowIndex, columnIndex))
+            }
+        }
+    }
+
+    while(queue.isNotEmpty()){
+        val current = queue.removeFirst()
+        for(i in rowDirection.indices){
+            val nextZ = current.first + zDirection[i]
+            val nextRow = current.second + rowDirection[i]
+            val nextColumn = current.third + columnDirection[i]
+            if(nextZ !in 0..<height || nextRow !in 0..<rows || nextColumn !in 0..<columns) continue
+            if(farm[nextZ][nextRow][nextColumn] != 0) continue
+            queue.addLast(Triple(nextZ, nextRow, nextColumn))
+            farm[nextZ][nextRow][nextColumn] = farm[current.first][current.second][current.third] + 1
+        }
+    }
+    var answer = 0
+    farm.forEach{ grid ->
+        grid.forEach{ row ->
+            row.forEach{ tomato ->
+                if(tomato==0){
+                    println(-1)
+                    return
+                }
+                if(tomato > answer) answer = tomato
+            }
+        }
+    }
+    println(answer-1)
+
+}


### PR DESCRIPTION
close #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 3차원 격자에서 토마토 익힘(BOJ 7569)을 해결하는 콘솔 프로그램을 추가했습니다. 초기 익은 토마토를 시작점으로 6방향으로 확산하며, 모든 칸이 익는 데 필요한 최소 일수를 계산해 출력합니다. 익힐 수 없는 경우 -1을 출력합니다. 다층 입력을 처리하고 여러 시작점을 자동 지원하며, 큐 기반 탐색으로 대규모 입력에서도 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->