### PR TITLE
[SOLVE] #132 백준 2667 풀이

### DIFF
--- a/src/main/java/baekjoon/barkingdog/bfs/Silver2667.kt
+++ b/src/main/java/baekjoon/barkingdog/bfs/Silver2667.kt
@@ -1,0 +1,49 @@
+package baekjoon.barkingdog.bfs
+
+fun main() {
+    val directions = arrayOf(
+        1 to 0,
+        -1 to 0,
+        0 to 1,
+        0 to -1
+    )
+    val size = readln().toInt()
+    val map = Array(size){
+        readln().toCharArray()
+    }
+    val visit = Array(size){
+        BooleanArray(size)
+    }
+    val extents = mutableListOf<Int>()
+    var area = 0
+    val queue = ArrayDeque<Pair<Int, Int>>()
+    for(rowIndex in 0..<size){
+        for(columnIndex in 0..<size){
+            if(map[rowIndex][columnIndex] == '0' || visit[rowIndex][columnIndex]) continue
+            queue.addLast(Pair(rowIndex, columnIndex))
+            visit[rowIndex][columnIndex] = true
+            area++
+            var extent = 0
+            while(queue.isNotEmpty()){
+                val current = queue.removeFirst()
+                extent++
+                for((rowDirection, columnDirection) in directions){
+                    val nextRow = current.first + rowDirection
+                    val nextColumn = current.second + columnDirection
+                    if(nextRow !in 0..<size || nextColumn !in 0..<size) continue
+                    if(map[nextRow][nextColumn] == '0' || visit[nextRow][nextColumn]) continue
+                    queue.addLast(nextRow to nextColumn)
+                    visit[nextRow][nextColumn] = true
+                }
+            }
+            extents.add(extent)
+        }
+    }
+    val result = buildString{
+        appendLine(area)
+        appendLine(
+            extents.sorted().joinToString(separator = "\n")
+        )
+    }
+    print(result)
+}


### PR DESCRIPTION
close #132 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BFS 기반의 BOJ 2667(단지번호붙이기) 솔루션을 추가했습니다. N×N 격자 입력에서 '1'을 집으로 간주해 연결된 단지를 탐색하고 각 단지의 크기를 계산합니다. 실행 결과로 첫 줄에 총 단지 수를, 이후 줄에 각 단지의 크기를 오름차순으로 출력합니다. 입력은 각 행이 공백 없이 제공되는 문자열 형태를 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->