### PR TITLE
[SOLVE] #176 백준 2630 풀이

### DIFF
--- a/src/main/java/baekjoon/barkingdog/recursion/Silver2630.kt
+++ b/src/main/java/baekjoon/barkingdog/recursion/Silver2630.kt
@@ -1,0 +1,48 @@
+package baekjoon.barkingdog.recursion
+
+fun main(){
+    val size = readln().toInt()
+    val paper = Array(size){
+        readln().split(" ").map{ it.toInt() }
+    }
+    val answer = intArrayOf(0,0)
+    dividePaper(0, 0, size, paper, answer)
+    answer.forEach {
+        println(it)
+    }
+}
+
+fun dividePaper(
+    startRow: Int,
+    startColumn: Int,
+    size: Int,
+    paper: Array<List<Int>>,
+    answer: IntArray
+){
+    val color =  paper[startRow][startColumn]
+    if(size == 1) {
+        when(color){
+            0 -> answer[0] += 1
+            1 -> answer[1] += 1
+        }
+        return
+    }
+    val nextSize = size / 2
+    for(row in startRow..<startRow + size){
+        for(column in startColumn..<startColumn + size){
+            if(color != paper[row][column]){
+                for(i in 0..<2){
+                    for(j in 0..<2){
+                        dividePaper(startRow + nextSize * i, startColumn + nextSize * j, nextSize, paper, answer)
+                    }
+                }
+                return
+            }
+        }
+    }
+    when(color){
+        0 -> answer[0] += 1
+        1 -> answer[1] += 1
+    }
+    return
+}


### PR DESCRIPTION
close #176 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 색종이의 흰색/파란색 단색 영역 개수를 계산하는 기능을 추가했습니다. 재귀적 4분할 방식을 통해 단색이면 즉시 집계하고, 혼합이면 네 구역으로 나눠 합산합니다. 표준 입력으로 한 변의 크기와 0/1 격자를 받아 처리하며, 결과로 각 색의 개수를 순서대로 출력합니다. 대규모 입력에서도 안정적으로 동작하도록 효율을 고려했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->